### PR TITLE
Make sure we don't crash the entire test if getting web driver session throws exception

### DIFF
--- a/src/JsErrorsDumper.php
+++ b/src/JsErrorsDumper.php
@@ -4,6 +4,7 @@ namespace Frontkom\CommonBehatDefinitions;
 
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Mink\Driver\Selenium2Driver;
+use Behat\Mink\Exception\DriverException;
 
 /**
  * Provides AfterStep that dumps any JS errors that appear during given step.
@@ -31,7 +32,14 @@ trait JsErrorsDumper {
     // example stuff like "Given a node with title something", which of course
     // will not let us have a browser window to check if there are any errors,
     // even if the driver of the session technically is a Selenium2Driver.
-    if (!$driver->getWebDriverSession()) {
+    try {
+      if (!$driver->getWebDriverSession()) {
+        return;
+      }
+    }
+    catch (DriverException $e) {
+      // This will happen at least in some version here if the session has not
+      // been started yet.
       return;
     }
 


### PR DESCRIPTION
**References** <!-- Link to the Jira task -->

### Changed <!-- What changed with this PR -->
I caught this error when I ran a single test that started without using the browser first

### Visuals <!-- Add here some screenshots -->
```
Feature: Search page should work

  Background:                             # vendor/nymedia/store8-tests/features/search/search.feature:4
    Given I run drush "eshd" "product -y" # Drupal\DrupalExtension\Context\DrushContext::assertDrushCommandWithArgument()
    │
    ╳  The driver is not started. (Behat\Mink\Exception\DriverException)
    │
    └─ @AfterStep # Nymedia\Tests\Context\FeatureContext::lookForJsErrors()
```

### How can this be validated? <!-- Instructions for QA -->

### Pull request checklist
- [x] Can be deploy automatically? _If manual actions are required:_ did you describe the deploy steps?
- [x] Is the documentation updated, if it makes sense? <!-- Check this also if no updating is needed -->
- [x] Are necessary translations added/updated? <!-- Check this even if no translations are being changed -->
- [x] Did you update sanitization routines, where personal information is handled?
