### PR TITLE
Move common behat definitions from Akademika

### DIFF
--- a/src/CommerceContext.php
+++ b/src/CommerceContext.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Frontkom\CommonBehatDefinitions;
+
+use Behat\Gherkin\Node\TableNode;
+use Drupal\commerce_promotion\Entity\Coupon;
+use Drupal\commerce_promotion\Entity\Promotion;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+/**
+ * Class CommerceContext.
+ *
+ * Provide Behat step-definitions for common Commerce functionalities.
+ */
+class CommerceContext extends RawDrupalContext {
+
+  /**
+   * Generate coupons.
+   *
+   * @Given coupons:
+   */
+  public function createCoupons(TableNode $nodesTable) {
+    foreach ($nodesTable->getHash() as $nodeHash) {
+      $coupon = (object) $nodeHash;
+      /** @var \Drupal\commerce_promotion\Entity\PromotionInterface $promotion */
+      $promotion = $this->getPromotionByName($coupon->promotion);
+      if ($promotion) {
+        $coupon_saved = $this->couponCreate($coupon);
+        $coupon_loaded = Coupon::load($coupon_saved->id);
+        $promotion->get('coupons')->appendItem($coupon_loaded);
+        $promotion->save();
+      }
+      else {
+        throw new \Exception("No parent promotion found.");
+      }
+    }
+  }
+
+  /**
+   * Load promotion by name.
+   */
+  public function getPromotionByName($promotion_name) {
+    foreach ($this->promotions as $promotion) {
+      $loaded_promotion = Promotion::load($promotion->id);
+      if ($loaded_promotion->label() === $promotion_name) {
+        return $loaded_promotion;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Create coupon.
+   */
+  public function couponCreate($coupon) {
+    $saved = $this->getDriver()->createEntity('commerce_promotion_coupon', $coupon);
+    return $saved;
+  }
+
+  /**
+   * Visit promotion edit page.
+   *
+   * @Then I visit promotion :title edit page
+   */
+  public function iVisitPromotionEditPage($title) {
+    $promotions = \Drupal::entityTypeManager()->getStorage('commerce_promotion')
+      ->loadByProperties([
+        'name' => $title,
+      ]);
+    if (count($promotions) !== 1) {
+      throw new \Exception('Expected 1 promotion with title ' . $title . ' but found ' . count($promotions));
+    }
+
+    $id = reset($promotions)->id();
+    $this->getSession()->visit($this->locatePath("promotion/$id/edit"));
+  }
+
+  /**
+   * Remove promotions by titles.
+   *
+   * @Then I remove promotions :titles
+   */
+  public function iRemovePromotions($titles) {
+    $promotions = \Drupal::entityTypeManager()->getStorage('commerce_promotion')
+      ->loadByProperties([
+        'name' => explode(', ', $titles),
+      ]);
+    foreach ($promotions as $promotion) {
+      $promotion->delete();
+    }
+  }
+
+  /**
+   * @Then /^a product with SKU "([^"]*)" should exist$/
+   */
+  public function aProductWithSKUShouldExist($sku) {
+    /** @var \Drupal\commerce_product\ProductVariationStorage $variation_storage */
+    $variation_storage = \Drupal::entityTypeManager()->getStorage('commerce_product_variation');
+    $product_variations = $variation_storage->loadBySku($sku);
+    if (empty($product_variations)) {
+      throw new \Exception('No variation found with SKU ' . $sku);
+    }
+  }
+
+  /**
+   * @Given I set :value exchange rates
+   */
+  public function setManualExchangeRates($value) {
+    $currency_storage = \Drupal::service('entity_type.manager')->getStorage('commerce_currency');
+    $currencies = $currency_storage->loadMultiple();
+    $currencies = array_keys($currencies);
+    $database = \Drupal::database();
+    $time = time();
+
+    foreach ($currencies as $currency) {
+      $query = $database->insert('commerce_exchanger_latest_rates')
+        ->fields([
+          'exchanger',
+          'source',
+          'target',
+          'value',
+          'timestamp',
+          'manual',
+        ]);
+
+      $query->values([
+        'exchanger' => 'manual',
+        'source' => $currency,
+        'target' => 'NOK',
+        'value' => $value,
+        'timestamp' => $time,
+        // A weird value just to identify records to remove in AfterScenario.
+        'manual' => '666666',
+      ]);
+      $query->execute();
+    }
+  }
+
+  /**
+   * Remove exchange rates.
+   *
+   * @AfterScenario
+   */
+  public function cleanExchangeRates() {
+    $database = \Drupal::database();
+    $database->delete('commerce_exchanger_latest_rates')
+      ->condition('manual', '666666', '=')
+      ->execute();
+  }
+
+}

--- a/src/CommonFeatureContext.php
+++ b/src/CommonFeatureContext.php
@@ -97,4 +97,63 @@ class CommonFeatureContext extends RawMinkContext
             throw new \Exception("ScrollIntoView failed: " . $e->getMessage());
         }
     }
+
+    /**
+     * @Then I( should) see the :tag element with the :attribute attribute set to :value
+     */
+    public function assertRegionElementAttribute($tag, $attribute, $value)
+    {
+        $elements = $this->getSession()->getPage()->findAll('css', $tag);
+        if (empty($elements)) {
+            throw new \Exception(sprintf('The element "%s" was not found on the page %s', $tag, $this->getSession()->getCurrentUrl()));
+        }
+        if (!empty($attribute)) {
+            $found = FALSE;
+            $attrfound = FALSE;
+            foreach ($elements as $element) {
+                $attr = $element->getAttribute($attribute);
+                if (NULL !== $attr) {
+                    $attrfound = TRUE;
+                    if (strpos($attr, "$value") !== FALSE) {
+                        $found = TRUE;
+                        break;
+                    }
+                }
+            }
+            if (!$found) {
+                if (!$attrfound) {
+                    throw new \Exception(sprintf('The "%s" attribute is not present on the element "%s" on the page %s', $attribute, $tag, $this->getSession()->getCurrentUrl()));
+                } else {
+                    throw new \Exception(sprintf('The "%s" attribute does not equal "%s" on the element "%s" on the page %s', $attribute, $value, $tag, $this->getSession()->getCurrentUrl()));
+                }
+            }
+        }
+    }
+
+    /**
+     * @Then /^I hover mouse over the "(?P<selector>[^"]*)" element$/
+     */
+    public function iHoverMouseOver($selector)
+    {
+        $page = $this->getSession()->getPage();
+        $element = $page->find('css', $selector);
+        if ($element === NULL) {
+            throw new \Exception("Element '$selector' NOT found");
+        }
+
+        $element->mouseOver();
+    }
+
+    /**
+     * The dirty but only way to test clicking without being redirected.
+     *
+     * @Given Link redirections are disabled
+     */
+    public function disableLinkRedirections()
+    {
+        $session = $this->minkContext->getSession();
+        $script = "jQuery('a').click(function (e) {e.preventDefault()});";
+        $session->evaluateScript($script);
+    }
+
 }

--- a/src/ContentContext.php
+++ b/src/ContentContext.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Frontkom\CommonBehatDefinitions;
+
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+/**
+ * Class ContentContext.
+ *
+ * Provide Behat step-definitions for content related operations.
+ */
+class ContentContext extends RawDrupalContext {
+
+  /**
+   * @Then I unpublish term :name
+   */
+  public function iUnpublishTerm($name) {
+    $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')
+      ->loadByProperties(['name' => $name]);
+
+    if ($term) {
+      $term = reset($term);
+      $term->setUnpublished();
+      $term->save();
+    }
+    else {
+      throw new \Exception("Term with name '$name' not found");
+    }
+  }
+
+}

--- a/src/DebuggingContext.php
+++ b/src/DebuggingContext.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Frontkom\CommonBehatDefinitions;
+
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+/**
+ * Class Debugging.
+ *
+ * Provide Behat step-definitions for actions helpful when debugging.
+ */
+class DebuggingContext extends RawDrupalContext {
+
+  /**
+   * Prints from watchdog at failed step.
+   *
+   * @AfterStep
+   */
+  public function logDumpAfterStep(AfterStepScope $scope) {
+    $failed = (99 === $scope->getTestResult()->getResultCode());
+    if ($failed) {
+      $query = \Drupal::database()
+        ->select('watchdog', 'w');
+
+      $query
+        ->range(0, 30)
+        ->fields('w')
+        ->orderBy('wid', 'DESC');
+      $rsc = $query->execute();
+      $table = [];
+      while ($result = $rsc->fetchObject()) {
+        $table[$result->wid] = (array) $result;
+      }
+      print_r($table);
+    }
+  }
+
+  /**
+   * Deletes from watchdog the logs that won't be related to the next scenario.
+   *
+   * @AfterScenario
+   */
+  public function deleteLogs() {
+    $query = \Drupal::database()
+      ->delete('watchdog');
+
+    $query->execute();
+  }
+
+}

--- a/src/TrackingContext.php
+++ b/src/TrackingContext.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Frontkom\CommonBehatDefinitions;
+
+use Behat\Gherkin\Node\TableNode;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+/**
+ * Class TrackingContext.
+ *
+ * Provide Behat step-definitions for operations related to tracking like GTM.
+ */
+class TrackingContext extends RawDrupalContext {
+
+  /**
+   * Check if commerce GTM event is fired with correct items.
+   *
+   * @Then A google event should be fired with name :name and items:
+   */
+  public function aGoogleEventShouldBeFiredWithItems($name, TableNode $nodesTable = NULL) {
+    $session = $this->minkContext->getSession();
+    $script = "return dataLayer;";
+    $dataLayer = $session->evaluateScript($script);
+
+    $events = array_filter($dataLayer, function ($element) {
+      return isset($element[0]) && $element[0] === 'event';
+    });
+
+    $searchedEvent = NULL;
+    foreach ($events as $event) {
+      if ($event[1] === $name) {
+        $searchedEvent = $event;
+      }
+    }
+
+    if (!$searchedEvent) {
+      throw new \Exception("GTM event with name '$name' is not present in the dataLayer.");
+    }
+
+    if (!$nodesTable) {
+      return;
+    }
+
+    if (!isset($searchedEvent[2])) {
+      throw new \Exception("GTM event with name '$name' has no parameters.");
+    }
+
+    if (!isset($searchedEvent[2]['items'])) {
+      throw new \Exception("GTM event with name '$name' has no items.");
+    }
+
+    $eventItems = $searchedEvent[2]['items'];
+    foreach ($nodesTable->getHash() as $nodeHash) {
+      // Try to find the search event with given params by comparing arrays.
+      $eventFound = FALSE;
+      foreach ($eventItems as $eventItem) {
+        $differences = array_diff($nodeHash, $eventItem);
+        if ($differences === []) {
+          $eventFound = TRUE;
+        }
+      }
+
+      if (!$eventFound) {
+        throw new \Exception("GTM event with name '$name' does not contain one of the given items.");
+      }
+    }
+  }
+
+}

--- a/src/UserContext.php
+++ b/src/UserContext.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Frontkom\CommonBehatDefinitions;
+
+use Drupal\Core\Url;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+/**
+ * Class UserContext.
+ *
+ * Provide Behat step-definitions for user related operations.
+ */
+class UserContext extends RawDrupalContext {
+
+  /**
+   * Helper to edit user.
+   *
+   * @When I edit user with email :mail
+   */
+  public function iEditUser($mail) {
+    $id = $this->getUserIdByMail($mail);
+    $this->visitPath('user/' . $id . '/edit');
+  }
+
+  /**
+   * Helper to visit a route with user param.
+   *
+   * @When I visit route :route with user parameter having mail :mail
+   */
+  public function iVisitRouteForUser($route, $mail) {
+    $id = $this->getUserIdByMail($mail);
+    $url = Url::fromRoute($route, ['user' => $id]);
+    $this->visitPath($url->toString());
+  }
+
+  /**
+   * Helper to get user ID.
+   */
+  private function getUserIdByMail($mail) {
+    $users = \Drupal::entityTypeManager()->getStorage('user')
+      ->getQuery()
+      ->condition('mail', $mail)
+      ->accessCheck()
+      ->execute();
+    if (empty($users)) {
+      throw new \Exception('No users found with email ' . $mail);
+    }
+    if (count($users) > 1) {
+      throw new \Exception('More than 1 user found with email ' . $mail);
+    }
+    return reset($users);
+  }
+
+}


### PR DESCRIPTION
**References** <!-- Link to the Jira task -->
AKA-71

### Changed <!-- What changed with this PR -->
I moved from Aka some behat steps definitions that seemed to me like it might be useful on other projects. I created a few contexts for granularity and I wonder if it makes sense to break CommerceContext into even more, entity-based contexts like ProductContext, PromotionContext, OrderContext (I guess there might be one in the future), let me know.

### Visuals <!-- Add here some screenshots -->
None

### How can this be validated? <!-- Instructions for QA -->
1. Use the Contexts in behat config file
2. Prepare a test using some of these steps
3. Run behat tests

### Pull request checklist
- [x] Can be deploy automatically? _If manual actions are required:_ did you describe the deploy steps?
- [x] Is the documentation updated, if it makes sense? <!-- Check this also if no updating is needed -->
- [x] Are necessary translations added/updated? <!-- Check this even if no translations are being changed -->
- [x] Did you update sanitization routines, where personal information is handled?
