### PR TITLE
Add a definition to wait for gutenberg

### DIFF
--- a/src/GutenbergContext.php
+++ b/src/GutenbergContext.php
@@ -20,4 +20,23 @@ class GutenbergContext extends RawMinkContext {
     $this->getSession()->evaluateScript($js);
   }
 
+  /**
+   * Step to wait for the editor to be ready.
+   *
+   * @Then /^I wait until gutenberg is ready$/
+   */
+  public function iWaitUntilGutenbergIsReady($max_wait = 10) {
+    while (TRUE) {
+      $is_ready = $this->getSession()->evaluateScript("wp && wp.data && wp.data.select && wp.data.select('core/editor').isCleanNewPost() || wp.data.select('core/block-editor').getBlockCount() > 0");
+      if ($is_ready) {
+        break;
+      }
+      sleep(1);
+      $max_wait--;
+      if ($max_wait <= 0) {
+        throw new \Exception('Gutenberg did not load in time');
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
### Changed <!-- What changed with this PR -->
Here we add a new step definition that waits for gutenberg to be ready. This reduces false positives or even false negatives when we want to assert certain things inside the editor

### Visuals <!-- Add here some screenshots -->

### How can this be validated? <!-- Instructions for QA -->

### Pull request checklist
- [x] Can be deploy automatically? _If manual actions are required:_ did you describe the deploy steps?
- [x] Is the documentation updated, if it makes sense? <!-- Check this also if no updating is needed -->
- [x] Are necessary translations added/updated? <!-- Check this even if no translations are being changed -->
- [x] Did you update sanitization routines, where personal information is handled?
